### PR TITLE
feat(cli): allow for mutation inputs in non-body locations

### DIFF
--- a/packages/cli/src/transformers/document-transformer.test.ts
+++ b/packages/cli/src/transformers/document-transformer.test.ts
@@ -5,9 +5,9 @@ import {
 	mutations,
 	queries,
 	widgetPaths,
-} from "./__fixtures__/widgets.fixtures.js";
+} from "../__fixtures__/widgets.fixtures.js";
+import { OASDocument, RPCDocument } from "../types/index.js";
 import { DocumentTransformer } from "./document-transformer.js";
-import { OASDocument, RPCDocument } from "./types";
 
 const healthCheck = {
 	"/health": {

--- a/packages/cli/src/transformers/document-transformer.ts
+++ b/packages/cli/src/transformers/document-transformer.ts
@@ -1,12 +1,12 @@
 import intersect from "just-intersect";
-import { OperationTransformer } from "./operation-transformer.js";
-import { getDefaultResolver } from "./resolver.js";
+import { getDefaultResolver } from "../resolver.js";
 import {
 	Logger,
 	OASDocument,
 	PathsObject,
 	RPCDocument,
-} from "./types/index.js";
+} from "../types/index.js";
+import { OperationTransformer } from "./operation-transformer.js";
 
 /**
  * Transforms an RPC document into an OAS document
@@ -61,7 +61,7 @@ export class DocumentTransformer {
 
 		for (const [operationId, operation] of Object.entries(rpc.mutations)) {
 			paths[`/mutations/${operationId}`] = {
-				post: this.transformer.transformMutationOperation(
+				post: await this.transformer.transformMutationOperation(
 					operationId,
 					operation
 				),

--- a/packages/cli/src/transformers/parameter-transformer.ts
+++ b/packages/cli/src/transformers/parameter-transformer.ts
@@ -1,0 +1,135 @@
+import {
+	OperationObject,
+	ParameterObject,
+	RPCParameterLocation,
+	RPCParameterObject,
+	RPCParametersObject,
+	SchemaObject,
+	assertObjectTypeSchema,
+} from "../types/index.js";
+
+export type TransformOutput = Pick<
+	OperationObject,
+	"requestBody" | "parameters"
+>;
+export type ParameterDefaults = RPCParameterObject & {
+	in: RPCParameterLocation;
+};
+
+/**
+ * transformRPCInputs takes an RPC input schema and transforms it into an OpenAPI requestBody and parameters
+ *
+ * @example
+ * ```typescript
+ * const inputSchema = schemas.CreateWidgetInput;
+ * const defaults = { in: 'body' };
+ * const overrides = {
+ *   userId: { in: 'path', required: true },
+ * };
+ * > transformRPCInputs(inputSchema, defaults, overrides);
+ * {
+ *   requestBody: {
+ *     required: true,
+ *     content: {
+ *       'application/json': {
+ *         schema: {
+ *           type: 'object',
+ *           required: ['status'],
+ *           properties: {
+ *             status: schemas.CreateWidgetInput.properties.status,
+ *           },
+ *         },
+ *       },
+ *     },
+ *   },
+ *   parameters: [
+ *     {
+ *       name: 'userId',
+ *       in: 'path',
+ *       required: true,
+ *       schema: schemas.CreateWidgetInput.properties.userId,
+ *     },
+ *   ],
+ * }
+ * ```
+ *
+ * @param inputSchema
+ * @param defaults values to use for parameters that are not overridden, primarily the `in` location
+ * @param overrides
+ * @returns
+ */
+export function transformRPCInputs(
+	inputSchema: SchemaObject,
+	defaults: ParameterDefaults,
+	overrides: RPCParametersObject = {}
+): TransformOutput {
+	assertObjectTypeSchema(
+		inputSchema,
+		"input schema must be an object type with properties"
+	);
+
+	if (Object.keys(overrides).length === 0 && defaults.in === "body") {
+		// easy case, no overrides and the input is a body
+		return {
+			requestBody: {
+				required: true,
+				content: {
+					"application/json": {
+						schema: inputSchema,
+					},
+				},
+			},
+		};
+	}
+
+	let hasParameters = false;
+	let hasBody = false;
+	const parameters: ParameterObject[] = [];
+	const bodySchema: SchemaObject = {
+		type: "object",
+		properties: {},
+		required: [],
+	};
+
+	for (const [name, schema] of Object.entries(inputSchema.properties)) {
+		const location = overrides[name]?.in ?? defaults.in;
+		if (location === "body") {
+			hasBody ||= true;
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			bodySchema.properties![name] = schema;
+			if (inputSchema.required?.includes(name)) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				bodySchema.required!.push(name);
+			}
+		} else {
+			hasParameters ||= true;
+
+			parameters.push({
+				name,
+				// @ts-expect-error tsc thinks that "body" is still an option
+				in: location,
+				schema,
+				...(inputSchema.required?.includes(name) ? { required: true } : {}),
+				...overrides[name],
+			});
+		}
+	}
+
+	if (!hasBody && !hasParameters) {
+		return {};
+	} else if (!hasBody) {
+		return { parameters };
+	} else {
+		const requestBody = {
+			required: true,
+			content: {
+				"application/json": {
+					schema: bodySchema,
+				},
+			},
+		};
+
+		return { requestBody, parameters };
+	}
+}

--- a/packages/cli/src/types/operations.ts
+++ b/packages/cli/src/types/operations.ts
@@ -1,3 +1,4 @@
+import { ParameterLocation } from "openapi3-ts/oas31.js";
 import {
 	MediaTypeObject,
 	ParameterObject as OASParameterObject,
@@ -5,19 +6,50 @@ import {
 	ResponsesObject,
 } from "./oas.js";
 
-export type RPCParameterObject = Partial<OASParameterObject>;
+export type RPCParameterLocation = ParameterLocation | "body";
+
+export type RPCParametersObject = Record<string, RPCParameterObject>;
+export type RPCParameterObject = Omit<
+	OASParameterObject,
+	"in" | "name" | "schema"
+> & {
+	in?: RPCParameterLocation;
+};
+
+export interface RPCInputObject extends MediaTypeObject {
+	/**
+	 * Allows for optional overriding of the location of specific parameters
+	 *
+	 * @example
+	 * ```yaml
+	 * input:
+	 *   schema: { $ref: '#/components/schemas/MyMutationInput' }
+	 *   parameters:
+	 *     arg1:
+	 *       in: path
+	 *       required: true
+	 */
+	parameters?: RPCParametersObject;
+}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface RPCOutputObject extends MediaTypeObject {}
 
 export interface RPCOperationObject
 	extends Omit<OperationObject, "operationId" | "requestBody" | "responses"> {
-	input?: MediaTypeObject;
+	/**
+	 * The input object for the operation
+	 *
+	 * NOTE: Optional if no input arguments are required
+	 */
+	input?: RPCInputObject;
+
 	/**
 	 * The response for the query operation
 	 *
 	 * NOTE: Optional for cases where the response is empty
 	 */
 	output?: RPCOutputObject;
+
 	/**
 	 * The OpenAPI error responses that that can be returned by the query operation
 	 * mapped to their HTTP status code
@@ -53,22 +85,8 @@ export interface RPCOperationObject
  * @todo add support for overriding the path
  *
  */
-export interface QueryOperationObject extends RPCOperationObject {
-	/**
-	 * The input object for the query operation
-	 *
-	 * NOTE: Optional if no input arguments are required
-	 */
-	input?: QueryInputObject;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface QueryInputObject extends MediaTypeObject {
-	/**
-	 * Allows for optional overriding of the location of specific parameters
-	 */
-	parameters?: Record<string, RPCParameterObject>;
-}
+export interface QueryOperationObject extends RPCOperationObject {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MutationOperationObject extends RPCOperationObject {}


### PR DESCRIPTION
Resolves #8 

* refactor: move transformers under a `transformers/` directory
* refactor: add a new `transformRPCInputs` method that optionally returns any of requestBody, parameters, or both
* refactor: unify `transformMutationOperation` and `transformQueryOperation`