### PR TITLE
chore(ci): attempt to get monorepo + release-please to work

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           release-type: node
           monorepo-tags: true
+          command: manifest
       # The logic below handles the npm publication:
       - uses: actions/checkout@v2
         # these if statements ensure that a publication only occurs when


### PR DESCRIPTION
Using https://github.com/remarkablemark/release-please-manifest-demo but may not be accurate since that's using a different repository root and version number